### PR TITLE
update schema model to camelCase

### DIFF
--- a/spec/data_flow_setup.md
+++ b/spec/data_flow_setup.md
@@ -93,13 +93,13 @@ AnonCreds credential of this type. The following is an example [[ref: Schema]]:
 {
   "name": "Example schema",
   "version": "0.0.1",
-  "attr_names": ["name", "age", "vmax"]
+  "attrNames": ["name", "age", "vmax"]
 }
 ```
 
 - `name` (string) - the name of the schema
 - `version` (string) - the schema version
-- `attr_names` (str[]) - an array of strings with each string being the name of an attribute of the schema
+- `attrNames` (str[]) - an array of strings with each string being the name of an attribute of the schema
 
 Once constructed, the [[ref: Schema]] is published to a Verifiable Data Registry
 (VDR) using the Schema Publishers selected [[ref: AnonCreds Objects Method]].

--- a/spec/diagrams/anoncreds-visual-data-model-overview.drawio
+++ b/spec/diagrams/anoncreds-visual-data-model-overview.drawio
@@ -27,7 +27,7 @@
                 <mxCell id="5c4Ob_BE5MfwwZ4g9xx3-27" value="+ version: string" style="text;strokeColor=none;fillColor=#FFFFFF;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;labelBackgroundColor=#FFFFFF;" parent="5c4Ob_BE5MfwwZ4g9xx3-1" vertex="1">
                     <mxGeometry y="78" width="170" height="22" as="geometry"/>
                 </mxCell>
-                <mxCell id="5c4Ob_BE5MfwwZ4g9xx3-4" value="+ attr_names: array&lt;string&gt;" style="text;strokeColor=none;fillColor=#FFFFFF;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;labelBackgroundColor=#FFFFFF;" parent="5c4Ob_BE5MfwwZ4g9xx3-1" vertex="1">
+                <mxCell id="5c4Ob_BE5MfwwZ4g9xx3-4" value="+ attrNames: array&lt;string&gt;" style="text;strokeColor=none;fillColor=#FFFFFF;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;labelBackgroundColor=#FFFFFF;" parent="5c4Ob_BE5MfwwZ4g9xx3-1" vertex="1">
                     <mxGeometry y="100" width="170" height="22" as="geometry"/>
                 </mxCell>
                 <mxCell id="5c4Ob_BE5MfwwZ4g9xx3-5" value="PRIVATE_CRED_DEF" style="swimlane;fontStyle=1;childLayout=stackLayout;horizontal=1;startSize=26;fillColor=#FFFFFF;horizontalStack=0;resizeParent=1;resizeParentMax=0;resizeLast=0;collapsible=1;marginBottom=0;labelBackgroundColor=#FFFFFF;" parent="1" vertex="1">
@@ -135,7 +135,7 @@
                 <mxCell id="5c4Ob_BE5MfwwZ4g9xx3-50" value="+ version: string" style="text;strokeColor=none;fillColor=default;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="5c4Ob_BE5MfwwZ4g9xx3-47" vertex="1">
                     <mxGeometry y="78" width="170" height="22" as="geometry"/>
                 </mxCell>
-                <mxCell id="jC2d6KhwjWWk40cOjQq3-31" value="+ attr_names: array&lt;string&gt;" style="text;strokeColor=none;fillColor=default;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="5c4Ob_BE5MfwwZ4g9xx3-47" vertex="1">
+                <mxCell id="jC2d6KhwjWWk40cOjQq3-31" value="+ attrNames: array&lt;string&gt;" style="text;strokeColor=none;fillColor=default;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="5c4Ob_BE5MfwwZ4g9xx3-47" vertex="1">
                     <mxGeometry y="100" width="170" height="30" as="geometry"/>
                 </mxCell>
                 <mxCell id="5c4Ob_BE5MfwwZ4g9xx3-51" value="+ signature: bytes" style="text;strokeColor=none;fillColor=default;align=left;verticalAlign=top;spacingLeft=4;spacingRight=4;overflow=hidden;rotatable=0;points=[[0,0.5],[1,0.5]];portConstraint=eastwest;" parent="5c4Ob_BE5MfwwZ4g9xx3-47" vertex="1">


### PR DESCRIPTION
Updates the schema model to use camelCase for the attrNames property. this is because the AnonCreds data models use camelCase by default. 

Model in AnonCreds RS (same as Indy Shared RS): https://github.com/hyperledger/anoncreds-rs/blob/main/anoncreds/src/data_types/anoncreds/schema.rs#L19-L26