### PR TITLE
new url context

### DIFF
--- a/.github/workflows/render-specs.yml
+++ b/.github/workflows/render-specs.yml
@@ -25,7 +25,7 @@ jobs:
           npm run render
           
     - name: Override gitignore
-      run: git add -f docs/index.html
+      run: git add -f docs/index.html docs/anoncreds-w3c-context
 
     - name: Deploy 🚀
       uses: JamesIves/github-pages-deploy-action@4.1.3

--- a/data/W3CCredential.json
+++ b/data/W3CCredential.json
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://raw.githubusercontent.com/hyperledger/anoncreds-spec/main/data/anoncreds-w3c-context.json"
+    "https://hyperledger.github.io/anoncreds-spec/anoncreds-w3c-context"
   ],
   "type": [
     "VerifiableCredential",

--- a/data/W3CCredentialWithRevocation.json
+++ b/data/W3CCredentialWithRevocation.json
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://raw.githubusercontent.com/hyperledger/anoncreds-spec/main/data/anoncreds-w3c-context.json"
+    "https://hyperledger.github.io/anoncreds-spec/anoncreds-w3c-context"
   ],
   "type": [
     "VerifiableCredential",

--- a/data/W3CPresentation.json
+++ b/data/W3CPresentation.json
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://raw.githubusercontent.com/hyperledger/anoncreds-spec/main/data/anoncreds-w3c-context.json"
+    "https://hyperledger.github.io/anoncreds-spec/anoncreds-w3c-context"
   ],
   "type": [
     "VerifiablePresentation",
@@ -11,7 +11,7 @@
     {
       "@context": [
         "https://www.w3.org/2018/credentials/v1",
-        "https://raw.githubusercontent.com/hyperledger/anoncreds-spec/main/data/anoncreds-w3c-context.json"
+        "https://hyperledger.github.io/anoncreds-spec/anoncreds-w3c-context"
       ],
       "type": [
         "VerifiableCredential",

--- a/data/W3CPresentationWithRevocation.json
+++ b/data/W3CPresentationWithRevocation.json
@@ -1,7 +1,7 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://raw.githubusercontent.com/hyperledger/anoncreds-spec/main/data/anoncreds-w3c-context.json"
+    "https://hyperledger.github.io/anoncreds-spec/anoncreds-w3c-context"
   ],
   "type": [
     "VerifiablePresentation",
@@ -11,7 +11,7 @@
     {
       "@context": [
         "https://www.w3.org/2018/credentials/v1",
-        "https://raw.githubusercontent.com/hyperledger/anoncreds-spec/main/data/anoncreds-w3c-context.json"
+        "https://hyperledger.github.io/anoncreds-spec/anoncreds-w3c-context"
       ],
       "type": [
         "VerifiableCredential",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "mocha": "^10.1.0"
   },
   "scripts": {
-    "render": "node -e \"require('spec-up')({ nowatch: true })\"",
+    "render": "node -e \"require('spec-up')({ nowatch: true })\" && cp data/anoncreds-w3c-context.json docs/anoncreds-w3c-context",
     "edit": "node -e \"require('spec-up')()\"",
     "test": "mocha 'test/**/*.js'"
   }

--- a/spec/w3c_representation.md
+++ b/spec/w3c_representation.md
@@ -29,7 +29,7 @@ The **context** definition used for AnonCreds W3C credentials representation can
 discovered [here](../data/anoncreds-w3c-context.json).
 
 In the case of W3C AnonCreds credentials, the `@context` attribute includes an extra
-entry `https://raw.githubusercontent.com/hyperledger/anoncreds-spec/main/data/anoncreds-w3c-context.json`
+entry `https://hyperledger.github.io/anoncreds-spec/anoncreds-w3c-context`
 which is required for the resolution of custom structure definitions and looks the following:
 
 ```json
@@ -37,7 +37,7 @@ which is required for the resolution of custom structure definitions and looks t
   ...
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://raw.githubusercontent.com/hyperledger/anoncreds-spec/main/data/anoncreds-w3c-context.json"
+    "https://hyperledger.github.io/anoncreds-spec/anoncreds-w3c-context"
   ],
   ...
 }
@@ -309,7 +309,7 @@ The **context** definition used for AnonCreds W3C presentations representation c
 discovered [here](../data/anoncreds-w3c-context.json).
 
 In the case of W3C AnonCreds presentations, the `@context` attribute includes an extra
-entry `https://raw.githubusercontent.com/hyperledger/anoncreds-spec/main/data/anoncreds-w3c-context.json`
+entry `https://hyperledger.github.io/anoncreds-spec/anoncreds-w3c-context`
 which is required for the resolution of custom structure definitions and looks the following:
 
 ```json
@@ -317,7 +317,7 @@ which is required for the resolution of custom structure definitions and looks t
   ...
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://raw.githubusercontent.com/hyperledger/anoncreds-spec/main/data/anoncreds-w3c-context.json"
+    "https://hyperledger.github.io/anoncreds-spec/anoncreds-w3c-context"
   ],
   ...
 }
@@ -492,7 +492,7 @@ It is [[ref: verifier]] and [[ref: holder]] responsibility to negotiate which pr
 ### Context
 
 The AnonCreds context, located
-at https://raw.githubusercontent.com/hyperledger/anoncreds-spec/main/data/anoncreds-w3c-context.json can be used to
+at https://hyperledger.github.io/anoncreds-spec/anoncreds-w3c-context can be used to
 implement a local cached copy.
 For convenience, the AnonCreds context is also provided in this section.
 


### PR DESCRIPTION
This deploys the context for anoncreds credentials on the spec site, allowing it to be accessed using https://hyperledger.github.io/anoncreds-w3c-context