### PR TITLE
Fix inconsistency: Rename 'prover_did' to 'entropy' in credential request JSON example

### DIFF
--- a/spec/data_flow_issuance.md
+++ b/spec/data_flow_issuance.md
@@ -157,7 +157,7 @@ The [[ref: holder]] constructs the following [[ref: Credential Request]] JSON st
 
 ```json
 {
-    "prover_did": "BZpdQDGp2ifid3u3Up17MG",
+    "entropy": "BZpdQDGp2ifid3u3Up17MG",
     "cred_def_id": "GvLGiRogTJubmj5B36qhYz:3:CL:8:faber.agent.degree_schema",
     "blinded_ms": {
         # Structure detailed below


### PR DESCRIPTION
This PR fixes issue #189 by correcting an inconsistency in the credential request JSON example. The field name was changed from "prover_did" to "entropy" in the JSON example to align with the explanatory text that follows it, ensuring consistency throughout the specification and preventing confusion for implementers working with AnonCreds.

Closes #189 